### PR TITLE
Remove Twitter search API usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # crewai-testinng
 
-This repository demonstrates how to use [CrewAI](https://github.com/crewAIInc/crewAI) to build a hierarchical agent system that searches for Twitter accounts related to a topic. Originally the example was provided as a Jupyter notebook, but a Python script is now included.
+This repository demonstrates how to use [CrewAI](https://github.com/crewAIInc/crewAI) to build a hierarchical agent system that collects Twitter accounts related to a topic without querying Twitter's search API. Originally the example was provided as a Jupyter notebook, but a Python script is now included. The notebook has been updated to use the same DuckDuckGo-based workflow.
 
-The new `duckduckgo_account_searcher.py` script searches **DuckDuckGo** for Twitter profiles matching a topic. It then verifies each profile via the Twitter API to ensure the account is real and active.
+The new `duckduckgo_account_searcher.py` script searches **DuckDuckGo** for Twitter profile links matching a topic. Each handle is then verified via the Twitter API to ensure the account is real and active, so no Twitter search queries are made.
 
 Before running the script, set the following environment variables with your API credentials:
 

--- a/twitter_account_searcher.ipynb
+++ b/twitter_account_searcher.ipynb
@@ -2,12 +2,12 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "33efc579",
+   "id": "2366f90b",
    "metadata": {},
    "source": [
     "# Twitter Account Discovery with CrewAI\n",
     "\n",
-    "This notebook demonstrates how to use [CrewAI](https://github.com/crewAIInc/crewAI) to build a hierarchical agent system that searches Twitter for accounts related to a topic. The search continues until 1000 unique accounts are gathered."
+    "This notebook demonstrates how to use [CrewAI](https://github.com/crewAIInc/crewAI) to build a hierarchical agent system that collects Twitter accounts related to a topic. Search results are gathered from DuckDuckGo to avoid querying Twitter directly."
    ]
   },
   {
@@ -26,7 +26,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install crewai tweepy -q"
+    "!pip install crewai tweepy duckduckgo-search -q"
    ]
   },
   {
@@ -78,7 +78,7 @@
    "id": "7d9fb826",
    "metadata": {},
    "source": [
-    "## Twitter search tool"
+    "## DuckDuckGo search tool"
    ]
   },
   {
@@ -90,8 +90,9 @@
    "source": [
     "import tweepy\n",
     "from typing import List, Dict\n",
+    "from duckduckgo_search import DDGS\n",
     "\n",
-    "class TwitterSearchTool:\n",
+    "class TwitterProfileTool:\n",
     "    def __init__(self):\n",
     "        auth = tweepy.OAuth1UserHandler(\n",
     "            TWITTER_CONSUMER_KEY,\n",
@@ -101,18 +102,33 @@
     "        )\n",
     "        self.api = tweepy.API(auth)\n",
     "\n",
-    "    def search_accounts(self, query: str, count: int = 20) -> List[Dict]:\n",
-    "        users = self.api.search_users(q=query, count=count)\n",
-    "        return [\n",
-    "            {\n",
+    "    def get_profile(self, username: str) -> Dict | None:\n",
+    "        try:\n",
+    "            user = self.api.get_user(screen_name=username)\n",
+    "            return {\n",
     "                'username': user.screen_name,\n",
     "                'name': user.name,\n",
     "                'description': user.description,\n",
     "                'followers': user.followers_count,\n",
     "                'profile_url': f'https://twitter.com/{user.screen_name}',\n",
     "            }\n",
-    "            for user in users\n",
-    "        ]\n"
+    "        except tweepy.TweepyException:\n",
+    "            return None\n",
+    "\n",
+    "class DuckDuckGoSearchTool:\n",
+    "    def search_accounts(self, query: str, count: int = 20) -> List[str]:\n",
+    "        with DDGS() as ddgs:\n",
+    "            results = ddgs.text(f\"site:twitter.com {query}\", max_results=count)\n",
+    "            handles = []\n",
+    "            for r in results:\n",
+    "                url = r.get('href') or r.get('url')\n",
+    "                if not url or 'twitter.com/' not in url:\n",
+    "                    continue\n",
+    "                username = url.split('twitter.com/')[-1].split('/')[0]\n",
+    "                username = username.lstrip('@').split('?')[0]\n",
+    "                if username and username not in handles:\n",
+    "                    handles.append(username)\n",
+    "        return handles\n"
    ]
   },
   {
@@ -136,7 +152,7 @@
     "    role='Account Finder',\n",
     "    goal='Identify Twitter accounts related to a given topic',\n",
     "    backstory='Expert at social media research and data collection',\n",
-    "    tools=[TwitterSearchTool()],\n",
+    "    tools=[DuckDuckGoSearchTool()],\n",
     "    verbose=True,\n",
     ")\n",
     "\n",
@@ -183,14 +199,20 @@
     "import pandas as pd\n",
     "\n",
     "def gather_accounts(topic: str, batch_size: int = 20) -> pd.DataFrame:\n",
+    "    searcher_tool = DuckDuckGoSearchTool()\n",
+    "    verifier = TwitterProfileTool()\n",
     "    unique = {}\n",
     "    page = 1\n",
     "    while len(unique) < 1000:\n",
     "        print(f'Searching batch {page}...')\n",
-    "        results = searcher.tools[0].search_accounts(query=topic, count=batch_size)\n",
-    "        for account in results:\n",
-    "            unique[account['username']] = account\n",
-    "        print(f'Total unique accounts: {len(unique)}')\n",
+    "        handles = searcher_tool.search_accounts(query=topic, count=batch_size)\n",
+    "        for handle in handles:\n",
+    "            if handle in unique:\n",
+    "                continue\n",
+    "            profile = verifier.get_profile(handle)\n",
+    "            if profile and profile['followers'] > 0:\n",
+    "                unique[handle] = profile\n",
+    "        print(f'Total unique verified accounts: {len(unique)}')\n",
     "        page += 1\n",
     "    return pd.DataFrame(list(unique.values()))\n"
    ]


### PR DESCRIPTION
## Summary
- switch notebook to DuckDuckGo search
- clarify in README that no Twitter search API calls occur

## Testing
- `python -m py_compile duckduckgo_account_searcher.py`
- `python - <<'EOF'
import nbformat
nbformat.validate(nbformat.read('twitter_account_searcher.ipynb', as_version=4))
print('valid')
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68699d6990d883309f451679538bf7d9